### PR TITLE
Update NweetFactory.js

### DIFF
--- a/src/components/NweetFactory.js
+++ b/src/components/NweetFactory.js
@@ -48,7 +48,9 @@ const NweetFactory = ({ userObj }) => {
       } = finishedEvent;
       setAttachment(result);
     };
-    reader.readAsDataURL(theFile);
+    if (Boolean(theFile)) {
+      reader.readAsDataURL(theFile);
+    }
   };
   const onClearAttachment = () => setAttachment("");
   return (


### PR DESCRIPTION
Error happens when I click file-upload-input and close it without uploading anything, right after I uploaded a file with the same input.
`TypeError: Failed to execute 'readAsDataURL' on 'FileReader': parameter 1 is not of type 'Blob'.`

So I added if-statement to the point where the FileReader reads theFile.

Always thank you for your awesome lectures!